### PR TITLE
fix(PrismicRichText): support reactive props

### DIFF
--- a/src/lib/PrismicRichText/PrismicRichText.svelte
+++ b/src/lib/PrismicRichText/PrismicRichText.svelte
@@ -48,10 +48,10 @@
 		| RichTextFunctionSerializer<typeof SvelteComponent, TreeNode>
 		| undefined = undefined;
 
-	let resolvedSerializer =
+	$: resolvedSerializer =
 		typeof components === "object" ? wrapMapSerializer(components) : components;
 
-	const nodes = asTree(field).children;
+	$: nodes = asTree(field).children;
 </script>
 
 <!--


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes a bug where `<PrismicRichText>` could not be used with reactive props. Slice Simulator is one example where props are reactive, where fields are edited client-side.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🐕
