### PR TITLE
fix(SliceZone): support Slice components without every Slice prop

### DIFF
--- a/src/SliceZone/SliceZone.svelte
+++ b/src/SliceZone/SliceZone.svelte
@@ -8,10 +8,10 @@
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		...args: any[]
 	) => SvelteComponent<{
-		slice: SliceLike;
-		slices: SliceLike[];
-		context: unknown;
-		index: number;
+		slice?: SliceLike;
+		slices?: SliceLike[];
+		context?: unknown;
+		index?: number;
 	}>;
 
 	type SliceComponents = Record<string, SvelteSliceComponent>;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR updates `<SliceZone>` to support Slice components that don't export all Slice props (`slice`, `slices`, `index`, `context`).

In many cases, Slice components do not need all four pieces of data.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
