### PR TITLE
fix(PrismicRichText): prevent extra whitespace between text

### DIFF
--- a/src/PrismicRichText/DefaultComponent.svelte
+++ b/src/PrismicRichText/DefaultComponent.svelte
@@ -48,9 +48,7 @@
 	<span class={node.data.label}><slot /></span>
 {:else}
 	{#each node.text.split("\n") as line, index}
-		{#if index > 0}
-			<br />
-		{/if}
-		{line}
+		<!-- This formatting is intentional to prevent unwanted whitespace between elements. -->
+		{#if index > 0}<br />{/if}{line}
 	{/each}
 {/if}

--- a/src/PrismicRichText/Serialize.svelte
+++ b/src/PrismicRichText/Serialize.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import type { RichTextNodeType } from "@prismicio/client";
 	import type { asTree } from "@prismicio/richtext";
 
 	import type { SvelteRichTextSerializer } from "../types";
@@ -9,28 +8,29 @@
 	export let components: SvelteRichTextSerializer = {};
 	export let children: ReturnType<typeof asTree>["children"];
 
-	const rewrittenNodeTypes: Partial<
-		Record<
-			(typeof RichTextNodeType)[keyof typeof RichTextNodeType],
-			keyof typeof RichTextNodeType
-		>
-	> = {
+	const CHILD_TYPE_RENAMES = {
 		"list-item": "listItem",
 		"o-list-item": "oListItem",
 		"group-list-item": "list",
 		"group-o-list-item": "oList",
-	};
+	} as const;
+
+	function getComponent(child: ReturnType<typeof asTree>["children"][number]) {
+		return (
+			components[
+				CHILD_TYPE_RENAMES[child.type as keyof typeof CHILD_TYPE_RENAMES] ||
+					(child.type as keyof typeof components)
+			] || DefaultComponent
+		);
+	}
 </script>
 
 {#each children as child}
-	<svelte:component
-		this={components[rewrittenNodeTypes[child.type] || child.type] ||
-			DefaultComponent}
-		node={child.node}
-		key={child.key}
+	<svelte:component this={getComponent(child)} node={child.node}>
+		<!-- This formatting is intentional to prevent unwanted whitespace between elements. -->
+		{#if child.children.length > 0}<svelte:self
+				children={child.children}
+				{components}
+			/>{/if}</svelte:component
 	>
-		{#if child.children.length > 0}
-			<svelte:self children={child.children} {components} />
-		{/if}
-	</svelte:component>
 {/each}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes a bug in `<PrismicRichText>` where extra whitespace was added between text.

The bug was apparent when labels and plain text were used. Should the bug appear in other block types, the same whitespace-elimination strategy can be used.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🐡
