### PR TITLE
fix: prevent flash of unwanted whitespace in `<PrismicRichText>`

### DIFF
--- a/src/PrismicRichText/DefaultComponent.svelte
+++ b/src/PrismicRichText/DefaultComponent.svelte
@@ -48,7 +48,6 @@
 	<span class={node.data.label}><slot /></span>
 {:else}
 	{#each node.text.split("\n") as line, index}
-		<!-- This formatting is intentional to prevent unwanted whitespace between elements. -->
 		{#if index > 0}<br />{/if}{line}
 	{/each}
 {/if}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes a bug in `<PrismicRichText>` where a flash of extra whitespace appeared at the start and end of blocks.

It was caused by an HTML comment, which has been removed.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
