### PR TITLE
fix(kit): support previews using a `/preview/` route prefix

### DIFF
--- a/src/kit/PrismicPreview.svelte
+++ b/src/kit/PrismicPreview.svelte
@@ -35,29 +35,37 @@
 	onMount(() => {
 		const controller = new AbortController();
 
-		window.addEventListener("prismicPreviewUpdate", (event) => {
-			event.preventDefault();
-			invalidateAll();
-		});
-		window.addEventListener("prismicPreviewEnd", (event) => {
-			event.preventDefault();
+		window.addEventListener(
+			"prismicPreviewUpdate",
+			(event) => {
+				event.preventDefault();
+				invalidateAll();
+			},
+			{ signal: controller.signal },
+		);
+		window.addEventListener(
+			"prismicPreviewEnd",
+			(event) => {
+				event.preventDefault();
 
-			endingPreview = true;
+				endingPreview = true;
 
-			goto(
-				new URL(
-					window.location.pathname.replace(
-						new RegExp(`^(\/${routePrefix}\/?$|\/${routePrefix}\/)`),
-						"/",
+				goto(
+					new URL(
+						window.location.pathname.replace(
+							new RegExp(`^(\/${routePrefix}\/?$|\/${routePrefix}\/)`),
+							"/",
+						),
+						window.location.origin,
 					),
-					window.location.origin,
-				),
-				{
-					invalidateAll: true,
-					noScroll: true,
-				},
-			);
-		});
+					{
+						invalidateAll: true,
+						noScroll: true,
+					},
+				);
+			},
+			{ signal: controller.signal },
+		);
 
 		return () => {
 			controller.abort();

--- a/src/kit/PrismicPreview.svelte
+++ b/src/kit/PrismicPreview.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onMount } from "svelte";
 	import { getToolbarSrc } from "@prismicio/client";
-	import { invalidateAll } from "$app/navigation";
+	import { beforeNavigate, goto, invalidateAll } from "$app/navigation";
 
 	/**
 	 * The name of your Prismic repository. A Prismic Toolbar will be registered
@@ -9,28 +9,85 @@
 	 */
 	export let repositoryName: string;
 
+	/**
+	 * The route parameter prefixed during preview sessions.
+	 */
+	export let routePrefix: string = "preview";
+
+	/**
+	 * The name of the preview-specific route parameter prefixed during preview
+	 * sessions.
+	 *
+	 * Only set this value if the route parameter's name differs from the
+	 * parameter's value.
+	 */
+	export let routePrefixName: string = routePrefix;
+
 	$: toolbarSrc = getToolbarSrc(repositoryName);
 
-	function prismicPreviewEventHandler(event: Event) {
-		event.preventDefault();
+	/**
+	 * Set to `true` when the next `beforeNavigate()` call should not prefix the
+	 * route.
+	 */
+	let endingPreview = false;
 
-		invalidateAll();
-	}
-
+	// Register Prismic toolbar event handlers to refresh data on content updates.
 	onMount(() => {
-		window.addEventListener("prismicPreviewUpdate", prismicPreviewEventHandler);
-		window.addEventListener("prismicPreviewEnd", prismicPreviewEventHandler);
+		const controller = new AbortController();
+
+		window.addEventListener("prismicPreviewUpdate", (event) => {
+			event.preventDefault();
+			invalidateAll();
+		});
+		window.addEventListener("prismicPreviewEnd", (event) => {
+			event.preventDefault();
+
+			endingPreview = true;
+
+			goto(
+				new URL(
+					window.location.pathname.replace(
+						new RegExp(`^(\/${routePrefix}\/?$|\/${routePrefix}\/)`),
+						"/",
+					),
+					window.location.origin,
+				),
+				{
+					invalidateAll: true,
+					noScroll: true,
+				},
+			);
+		});
 
 		return () => {
-			window.removeEventListener(
-				"prismicPreviewUpdate",
-				prismicPreviewEventHandler,
-			);
-			window.removeEventListener(
-				"prismicPreviewEnd",
-				prismicPreviewEventHandler,
-			);
+			controller.abort();
 		};
+	});
+
+	beforeNavigate((navigation) => {
+		// Prefix links with the preview route parameter if the current
+		// route is in a preview session.
+		if (
+			navigation.to &&
+			navigation.from?.params?.[routePrefixName] === routePrefix &&
+			!(routePrefixName in (navigation.to.params || {}))
+		) {
+			// If this callback is called due to a `prismicPreviewEnd`
+			// event, don't prefix the route. The exception is only
+			// valid for one call.
+			if (endingPreview) {
+				endingPreview = false;
+				return;
+			}
+
+			navigation.cancel();
+			goto(
+				new URL(
+					routePrefix + navigation.to.url.pathname,
+					navigation.to.url.origin,
+				),
+			);
+		}
 	});
 </script>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR updates the existing `@prismicio/svelte/kit` preview functions and components to support a new, cleaner method of integrating Prismic previews.

- `redirectToPreviewURL()` now prefixes routes with `/preview/` (configurable), which enables server rendering.
- `<PrismicPreview>` now adds a special navigation handler to prefix links with `/preview/` (configurable), which enables server rendering.

Documentation on the recommended SvelteKit app setup and `@prismicio/svelte/kit`'s API will be published soon.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
