### PR TITLE
feat(SliceZone): add support for mapped Slice Zones created with `@prismicio/client`'s `unstable_mapSliceZone()`

### DIFF
--- a/src/SliceZone/SliceZone.svelte
+++ b/src/SliceZone/SliceZone.svelte
@@ -48,9 +48,18 @@
 	 *
 	 * @typeParam SliceType - Type name of the Slice.
 	 */
-	type SliceLike<SliceType extends string = string> =
+	type SliceLike<SliceType extends string = string> = (
 		| SliceLikeRestV2<SliceType>
-		| SliceLikeGraphQL<SliceType>;
+		| SliceLikeGraphQL<SliceType>
+	) & {
+		/**
+		 * If `true`, this Slice has been modified from its original value using a
+		 * mapper and `@prismicio/client`'s `mapSliceZone()`.
+		 *
+		 * @internal
+		 */
+		__mapped?: true;
+	};
 
 	/**
 	 * An array of Prismic Slices, such as the `slices` property from a Prismic
@@ -108,7 +117,12 @@
 	{@const type = "slice_type" in slice ? slice.slice_type : slice.type}
 	{@const Component = components[type] || defaultComponent}
 	{#if Component}
-		<svelte:component this={Component} {slice} {slices} {context} {index} />
+		{#if slice.__mapped}
+			{@const { __mapped, ...mappedProps } = slice}
+			<svelte:component this={Component} {...mappedProps} />
+		{:else}
+			<svelte:component this={Component} {slice} {slices} {context} {index} />
+		{/if}
 	{:else}
 		<TodoComponent {slice} />
 	{/if}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds support for `@prismicio/client`'s `mapSliceZone()` to `<SliceZone>`.

`mapSliceZone()` adds a `__mapped` property used to detect mapped Slices. `<SliceZone>` detects the `__mapped` property and automatically spreads the Slice's properties as props. An unmapped Slice will continue to provide the standard `{ slice, index, slices, context }` props.

### Example

```typescript
// +page.server.js

const mappedSliceZone = await prismic.mapSliceZone(page.data.slices, {
  foo: () => ({ foo: "bar" }),
  bar: () => ({ baz: "qux" }),
});
```

```svelte
<script>
	import { SliceZone } from '@prismicio/svelte';

	import { components } from '$lib/slices';

	export let data;
</script>

<!-- The `foo` and `bar` components will receive the props returned in the functions above. -->
<SliceZone slices={data.slices} {components} />
```

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🦆
