### PR TITLE
chore: add svelte 5 as a peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
 			"peerDependencies": {
 				"@prismicio/client": ">=7",
 				"@sveltejs/kit": ">=1",
-				"svelte": ">=4"
+				"svelte": ">=4 || ^5.0.0"
 			},
 			"peerDependenciesMeta": {
 				"@sveltejs/kit": {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
 	"peerDependencies": {
 		"@prismicio/client": ">=7",
 		"@sveltejs/kit": ">=1",
-		"svelte": ">=4"
+		"svelte": ">=4 || ^5.0.0"
 	},
 	"peerDependenciesMeta": {
 		"@sveltejs/kit": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

Add Svelte 5 as a peer dependency.

It seems that Svelte 5 components will through type errors when passed as props (e.g. to the `components` prop of `SliceZone` and `PrismicRichText`), but otherwise the package seems to work in Svelte 5 projects.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [ ] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [ ] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
