### PR TITLE
fix(helpers): add missing `dir` attribute for right-to-left languages

### DIFF
--- a/src/PrismicRichText/DefaultComponent.svelte
+++ b/src/PrismicRichText/DefaultComponent.svelte
@@ -6,22 +6,24 @@
 	import PrismicLink from "../PrismicLink.svelte";
 
 	export let node: RTAnyNode;
+
+	$: dir = "direction" in node && node.direction === "rtl" ? "rtl" : undefined
 </script>
 
 {#if node.type === "heading1"}
-	<h1><slot /></h1>
+	<h1 {dir}><slot /></h1>
 {:else if node.type === "heading2"}
-	<h2><slot /></h2>
+	<h2 {dir}><slot /></h2>
 {:else if node.type === "heading3"}
-	<h3><slot /></h3>
+	<h3 {dir}><slot /></h3>
 {:else if node.type === "heading4"}
-	<h4><slot /></h4>
+	<h4 {dir}><slot /></h4>
 {:else if node.type === "heading5"}
-	<h5><slot /></h5>
+	<h5 {dir}><slot /></h5>
 {:else if node.type === "heading6"}
-	<h6><slot /></h6>
+	<h6 {dir}><slot /></h6>
 {:else if node.type === "paragraph"}
-	<p><slot /></p>
+	<p {dir}><slot /></p>
 {:else if node.type === "preformatted"}
 	<pre><slot /></pre>
 {:else if node.type === "strong"}
@@ -29,9 +31,9 @@
 {:else if node.type === "em"}
 	<em><slot /></em>
 {:else if node.type === "list-item"}
-	<li><slot /></li>
+	<li {dir}><slot /></li>
 {:else if node.type === "o-list-item"}
-	<li><slot /></li>
+	<li {dir}><slot /></li>
 {:else if node.type === "group-list-item"}
 	<ul><slot /></ul>
 {:else if node.type === "group-o-list-item"}


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

**Resolves**: https://prismic-team.slack.com/archives/C014VAACCQL/p1729780207755199

### Description

This PR updates the default richtext serializer to honor the `direction` property of rich text nodes and adds the appropriate `dir` attribute on right-to-left text nodes.

Related:
- `@prismicio/client` PR: https://github.com/prismicio/prismic-client/pull/357
- `@prismicio/react` PR: https://github.com/prismicio/prismic-react/pull/211

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [x] If my changes require tests, I added them.
- [x] If my changes affect backward compatibility, it has been discussed.
- [x] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.