### PR TITLE
feat: support shorthand component definition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1133,6 +1133,7 @@
 			"integrity": "sha512-4ijxHuuzwwH4hU+QVrpGwEEBPST1D3fjqW37aXbDVhTnZbedrx/jkblGQpRisLs3m7AANuzpm46UNLWcgUDZKw==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"imgix-url-builder": "^0.0.6"
 			},
@@ -1549,6 +1550,7 @@
 			"integrity": "sha512-MCFS6CrQDu1yGwspm4qtli0e63vaPCehf6V7pIMP15AsWgMKrqDGCPFF/0kn4SP0ii4aySu4Pa62+fIRGFMjgw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@sveltejs/vite-plugin-svelte-inspector": "^4.0.1",
 				"debug": "^4.4.0",
@@ -1732,6 +1734,7 @@
 			"integrity": "sha512-v1DKRfUdyW+jJhZNEI1PYy29S2YRxMV5AOO/x/SjKmW0acCIOqmbj6Haf9eHAhsPmrhlHSxEhv/1WszcLWV4cg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"undici-types": "~6.21.0"
 			}
@@ -1786,6 +1789,7 @@
 			"integrity": "sha512-LKMrmwCPoLhM45Z00O1ulb6jwyVr2kr3XJp+G+tSEZcbauNnScewcQwtJqXDhXeYPDEjZ8C1SjXm015CirEmGg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.32.1",
 				"@typescript-eslint/types": "8.32.1",
@@ -2095,6 +2099,7 @@
 			"integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -3251,6 +3256,7 @@
 			"integrity": "sha512-ixRawFQuMB9DZ7fjU3iGGganFDp3+45bPOdaRurcFHSXO1e/sYwUX/FtQZpLZJR6SjMoJH8hR2pPEAfDyCoU2Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -3312,6 +3318,7 @@
 			"integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"eslint-config-prettier": "bin/cli.js"
 			},
@@ -4020,6 +4027,7 @@
 			"integrity": "sha512-NZypxadhCiV5NT4A+Y86aQVVKQ05KDmueja3sz008uJfDRwz028wd0aTiJPwo4RQlvlz0fznkEEBBCHVNWc08g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"webidl-conversions": "^7.0.0",
 				"whatwg-mimetype": "^3.0.0"
@@ -5825,6 +5833,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.8",
 				"picocolors": "^1.1.1",
@@ -5977,6 +5986,7 @@
 			"integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -6024,6 +6034,7 @@
 			"integrity": "sha512-pn1ra/0mPObzqoIQn/vUTR3ZZI6UuZ0sHqMK5x2jMLGrs53h0sXhkVuDcrlssHwIMk7FYrMjHBPoUSyyEEDlBQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"peerDependencies": {
 				"prettier": "^3.0.0",
 				"svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0"
@@ -6543,6 +6554,7 @@
 			"integrity": "sha512-2kpQq2DD/pRpx3Tal/qRW1SYwcIeQ0iq8li5CJHQgOC+FtPn2BVmuDtzUCgNnpCrbgtfEHqh+iWzxK+Tq6C+RQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"bytes-iec": "^3.1.1",
 				"chokidar": "^4.0.3",
@@ -6955,6 +6967,7 @@
 			"integrity": "sha512-QIYtKnJGkubWXtNkrUBKVCvyo9gjcccdbnvXfwsGNhvbeNNdQjRDTa/BiQcJ2kWXbXPQbWKyT7CUu53KIj1rfw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.3.0",
 				"@jridgewell/sourcemap-codec": "^1.5.0",
@@ -7153,6 +7166,7 @@
 			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -7282,6 +7296,7 @@
 			"integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -7382,6 +7397,7 @@
 			"integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.25.0",
 				"fdir": "^6.4.4",
@@ -7495,6 +7511,7 @@
 			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -7527,6 +7544,7 @@
 			"integrity": "sha512-188iM4hAHQ0km23TN/adso1q5hhwKqUpv+Sd6p5sOuh6FhQnRNW3IsiIpvxqahtBabsJ2SLZgmGSpcYK4wQYJw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@vitest/expect": "3.1.3",
 				"@vitest/mocker": "3.1.3",
@@ -7773,21 +7791,6 @@
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/yaml": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-			"integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-			"dev": true,
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"bin": {
-				"yaml": "bin.mjs"
-			},
-			"engines": {
-				"node": ">= 14.6"
-			}
 		},
 		"node_modules/yargs": {
 			"version": "16.2.0",

--- a/src/PrismicRichText/DefaultComponent.svelte
+++ b/src/PrismicRichText/DefaultComponent.svelte
@@ -1,57 +1,76 @@
 <script lang="ts">
-	import type { RichTextComponentProps } from "../types";
+	import type { ComponentShorthand, RichTextComponentProps } from "../types";
 
 	import PrismicEmbed from "../PrismicEmbed.svelte";
 	import PrismicImage from "../PrismicImage.svelte";
 	import PrismicLink from "../PrismicLink.svelte";
 
-	type Props = RichTextComponentProps;
+	type Props = RichTextComponentProps & { shorthand?: ComponentShorthand };
 
-	const { node, children }: Props = $props();
+	const { node, children, shorthand }: Props = $props();
+
+	const as = $derived(
+		node.type !== "image" && node.type !== "span"
+			? shorthand?.as
+			: undefined
+	);
+
+	const attrs = $derived.by(() => {
+		const { as, ...attrs } = shorthand ?? {};
+		return attrs;
+	});
 
 	const dirProp = $derived(
 		"direction" in node && node.direction === "rtl" ? { direction: "rtl" } : {},
 	);
 </script>
 
-{#if node.type === "heading1"}
-	<h1 {...dirProp}>{@render children()}</h1>
+{#if as}
+	<svelte:element this={as} {...dirProp} {...attrs}>{@render children()}</svelte:element>
+{:else if node.type === "heading1"}
+	<h1 {...dirProp} {...attrs}>{@render children()}</h1>
 {:else if node.type === "heading2"}
-	<h2 {...dirProp}>{@render children()}</h2>
+	<h2 {...dirProp} {...attrs}>{@render children()}</h2>
 {:else if node.type === "heading3"}
-	<h3 {...dirProp}>{@render children()}</h3>
+	<h3 {...dirProp} {...attrs}>{@render children()}</h3>
 {:else if node.type === "heading4"}
-	<h4 {...dirProp}>{@render children()}</h4>
+	<h4 {...dirProp} {...attrs}>{@render children()}</h4>
 {:else if node.type === "heading5"}
-	<h5 {...dirProp}>{@render children()}</h5>
+	<h5 {...dirProp} {...attrs}>{@render children()}</h5>
 {:else if node.type === "heading6"}
-	<h6 {...dirProp}>{@render children()}</h6>
+	<h6 {...dirProp} {...attrs}>{@render children()}</h6>
 {:else if node.type === "paragraph"}
-	<p {...dirProp}>{@render children()}</p>
+	<p {...dirProp} {...attrs}>{@render children()}</p>
 {:else if node.type === "preformatted"}
-	<pre>{@render children()}</pre>
+	<pre {...attrs}>{@render children()}</pre>
 {:else if node.type === "strong"}
-	<strong>{@render children()}</strong>
+	<strong {...attrs}>{@render children()}</strong>
 {:else if node.type === "em"}
-	<em>{@render children()}</em>
+	<em {...attrs}>{@render children()}</em>
 {:else if node.type === "list-item"}
-	<li {...dirProp}>{@render children()}</li>
+	<li {...dirProp} {...attrs}>{@render children()}</li>
 {:else if node.type === "o-list-item"}
-	<li {...dirProp}>{@render children()}</li>
+	<li {...dirProp} {...attrs}>{@render children()}</li>
 {:else if node.type === "group-list-item"}
-	<ul>{@render children()}</ul>
+	<ul {...attrs}>{@render children()}</ul>
 {:else if node.type === "group-o-list-item"}
-	<ol>{@render children()}</ol>
+	<ol {...attrs}>{@render children()}</ol>
 {:else if node.type === "image"}
 	<p class="block-img">
-		<PrismicImage field={node} />
+		{#if node.linkTo}
+			<PrismicLink field={node.linkTo}>
+				<PrismicImage field={node} {...attrs} />
+			</PrismicLink>
+		{:else}
+			<PrismicImage field={node} {...attrs} />
+		{/if}
 	</p>
 {:else if node.type === "embed"}
-	<PrismicEmbed field={node.oembed} />
+	<PrismicEmbed field={node.oembed} {...attrs} />
 {:else if node.type === "hyperlink"}
-	<PrismicLink field={node.data}>{@render children()}</PrismicLink>
+	<PrismicLink field={node.data} {...attrs}>{@render children()}</PrismicLink>
 {:else if node.type === "label"}
-	<span class={node.data.label}>{@render children()}</span>
+	<span class={node.data.label} {...attrs}>{@render children()}</span>
 {:else}
 	{#each node.text.split("\n") as line, index (index)}
 		{#if index > 0}<br />{/if}{line}

--- a/src/PrismicRichText/DefaultComponent.svelte
+++ b/src/PrismicRichText/DefaultComponent.svelte
@@ -10,13 +10,11 @@
 	const { node, children, shorthand }: Props = $props();
 
 	const as = $derived(
-		node.type !== "image" && node.type !== "span"
-			? shorthand?.as
-			: undefined
+		node.type !== "image" && node.type !== "span" ? shorthand?.as : undefined,
 	);
 
 	const attrs = $derived.by(() => {
-		const { as, ...attrs } = shorthand ?? {};
+		const { as: _, ...attrs } = shorthand ?? {};
 		return attrs;
 	});
 
@@ -26,7 +24,9 @@
 </script>
 
 {#if as}
-	<svelte:element this={as} {...dirProp} {...attrs}>{@render children()}</svelte:element>
+	<svelte:element this={as} {...dirProp} {...attrs}
+		>{@render children()}</svelte:element
+	>
 {:else if node.type === "heading1"}
 	<h1 {...dirProp} {...attrs}>{@render children()}</h1>
 {:else if node.type === "heading2"}

--- a/src/PrismicRichText/PrismicRichText.svelte
+++ b/src/PrismicRichText/PrismicRichText.svelte
@@ -2,8 +2,10 @@
 	import type { RichTextField } from "@prismicio/client";
 	import { asTree } from "@prismicio/client/richtext";
 
-	import type { RichTextComponents } from "../types";
+	import type { RichTextComponent, RichTextComponents, ComponentShorthand, InternalRichTextComponents } from "../types";
+	import { isSvelteComponent } from "../types";
 
+	import DefaultComponent from "./DefaultComponent.svelte";
 	import Serialize from "./Serialize.svelte";
 
 	type Props = {
@@ -21,6 +23,38 @@
 	const { field, components = {} }: Props = $props();
 
 	const children = $derived(asTree(field).children);
+
+	function getInternalComponent(type: keyof RichTextComponents) {
+		const maybeComponentOrShorthand = components?.[type] as RichTextComponent | ComponentShorthand | undefined;
+
+		if (isSvelteComponent(maybeComponentOrShorthand)) {
+			return { is: maybeComponentOrShorthand };
+		}
+
+		return { is: DefaultComponent, shorthand: maybeComponentOrShorthand };
+	}
+
+	const internalComponents = $derived<InternalRichTextComponents>({
+		heading1: getInternalComponent("heading1"),
+		heading2: getInternalComponent("heading2"),
+		heading3: getInternalComponent("heading3"),
+		heading4: getInternalComponent("heading4"),
+		heading5: getInternalComponent("heading5"),
+		heading6: getInternalComponent("heading6"),
+		paragraph: getInternalComponent("paragraph"),
+		preformatted: getInternalComponent("preformatted"),
+		strong: getInternalComponent("strong"),
+		em: getInternalComponent("em"),
+		"list-item": getInternalComponent("listItem"),
+		"o-list-item": getInternalComponent("oListItem"),
+		"group-list-item": getInternalComponent("list"),
+		"group-o-list-item": getInternalComponent("oList"),
+		image: getInternalComponent("image"),
+		embed: getInternalComponent("embed"),
+		hyperlink: getInternalComponent("hyperlink"),
+		label: getInternalComponent("label"),
+		span: getInternalComponent("span"),
+	});
 </script>
 
 <!--
@@ -33,4 +67,4 @@
 	```
 -->
 
-<Serialize {children} {components} />
+<Serialize {children} {internalComponents} />

--- a/src/PrismicRichText/PrismicRichText.svelte
+++ b/src/PrismicRichText/PrismicRichText.svelte
@@ -2,7 +2,12 @@
 	import type { RichTextField } from "@prismicio/client";
 	import { asTree } from "@prismicio/client/richtext";
 
-	import type { RichTextComponent, RichTextComponents, ComponentShorthand, InternalRichTextComponents } from "../types";
+	import type {
+		RichTextComponent,
+		RichTextComponents,
+		ComponentShorthand,
+		InternalRichTextComponents,
+	} from "../types";
 	import { isSvelteComponent } from "../types";
 
 	import DefaultComponent from "./DefaultComponent.svelte";
@@ -25,7 +30,10 @@
 	const children = $derived(asTree(field).children);
 
 	function getInternalComponent(type: keyof RichTextComponents) {
-		const maybeComponentOrShorthand = components?.[type] as RichTextComponent | ComponentShorthand | undefined;
+		const maybeComponentOrShorthand = components?.[type] as
+			| RichTextComponent
+			| ComponentShorthand
+			| undefined;
 
 		if (isSvelteComponent(maybeComponentOrShorthand)) {
 			return { is: maybeComponentOrShorthand };

--- a/src/PrismicRichText/Serialize.svelte
+++ b/src/PrismicRichText/Serialize.svelte
@@ -1,42 +1,26 @@
 <script lang="ts">
 	import type { asTree } from "@prismicio/client/richtext";
 
-	import type { RichTextComponent, RichTextComponents } from "../types";
+	import type { InternalRichTextComponents } from "../types";
 
-	import DefaultComponent from "./DefaultComponent.svelte";
 	import Serialize from "./Serialize.svelte";
 
 	type Props = {
-		components: RichTextComponents;
+		internalComponents: InternalRichTextComponents;
 		children: ReturnType<typeof asTree>["children"];
 	};
 
-	const { components, children }: Props = $props();
-
-	const CHILD_TYPE_RENAMES = {
-		"list-item": "listItem",
-		"o-list-item": "oListItem",
-		"group-list-item": "list",
-		"group-o-list-item": "oList",
-	} as const;
-
-	function getComponent(child: ReturnType<typeof asTree>["children"][number]) {
-		return (
-			(components[
-				CHILD_TYPE_RENAMES[child.type as keyof typeof CHILD_TYPE_RENAMES] ||
-					(child.type as keyof typeof components)
-			] as RichTextComponent) || DefaultComponent
-		);
-	}
+	const { internalComponents, children }: Props = $props();
 </script>
 
 {#each children as child (child.key)}
-	{@const Component = getComponent(child)}
-	<Component node={child.node}>
+	{@const Component = internalComponents[child.type].is}
+	{@const shorthand = internalComponents[child.type].shorthand}
+	<Component node={child.node} {shorthand}>
 		<!-- This formatting is intentional to prevent unwanted whitespace between elements. -->
 		{#if child.children.length > 0}<Serialize
 				children={child.children}
-				{components}
+				{internalComponents}
 			/>{/if}</Component
 	>
 {/each}

--- a/src/PrismicTable/DefaultComponent.svelte
+++ b/src/PrismicTable/DefaultComponent.svelte
@@ -1,14 +1,22 @@
 <script lang="ts">
 	import type { Snippet } from "svelte";
 
-	import type { TableComponents } from "../types";
+	import type { ComponentShorthand, TableComponents } from "../types";
 
 	type Props = {
-		type: keyof TableComponents;
+		type?: keyof TableComponents;
 		children: Snippet;
+		shorthand?: ComponentShorthand;
 	};
 
-	const { type, children }: Props = $props();
+	const { type, children, shorthand }: Props = $props();
+
+	const as = $derived(shorthand?.as ?? type);
+
+	const attrs = $derived.by(() => {
+		const { as, ...attrs } = shorthand ?? {};
+		return attrs;
+	});
 </script>
 
-<svelte:element this={type}>{@render children()}</svelte:element>
+<svelte:element this={as} {...attrs}>{@render children()}</svelte:element>

--- a/src/PrismicTable/DefaultComponent.svelte
+++ b/src/PrismicTable/DefaultComponent.svelte
@@ -14,7 +14,7 @@
 	const as = $derived(shorthand?.as ?? type);
 
 	const attrs = $derived.by(() => {
-		const { as, ...attrs } = shorthand ?? {};
+		const { as: _, ...attrs } = shorthand ?? {};
 		return attrs;
 	});
 </script>

--- a/src/PrismicTable/PrismicTable.svelte
+++ b/src/PrismicTable/PrismicTable.svelte
@@ -2,7 +2,7 @@
 	import { type TableField, isFilled } from "@prismicio/client";
 	import { type Component } from "svelte";
 
-	import type { RichTextComponents, TableComponents } from "../types";
+	import { isSvelteComponent, type RichTextComponents, type TableComponents } from "../types";
 
 	import PrismicRichText from "../PrismicRichText/PrismicRichText.svelte";
 
@@ -28,34 +28,51 @@
 
 	const { field, components = {}, fallback: Fallback }: Props = $props();
 
-	const Table = components.table ?? DefaultComponent;
-	const Thead = components.thead ?? DefaultComponent;
-	const Tbody = components.tbody ?? DefaultComponent;
-	const Tr = components.tr ?? DefaultComponent;
-	const Th = components.th ?? DefaultComponent;
-	const Td = components.td ?? DefaultComponent;
+	const { Table, tableProps } = isSvelteComponent(components.table)
+		? { Table: components.table }
+		: { Table: DefaultComponent, tableProps: { type: "table", shorthand: components.table } as const };
+
+	const { Thead, theadProps } = isSvelteComponent(components.thead)
+		? { Thead: components.thead }
+		: { Thead: DefaultComponent, theadProps: { type: "thead", shorthand: components.thead } as const };
+
+	const { Tbody, tbodyProps } = isSvelteComponent(components.tbody)
+		? { Tbody: components.tbody }
+		: { Tbody: DefaultComponent, tbodyProps: { type: "tbody", shorthand: components.tbody } as const };
+
+	const { Tr, trProps } = isSvelteComponent(components.tr)
+		? { Tr: components.tr }
+		: { Tr: DefaultComponent, trProps: { type: "tr", shorthand: components.tr } as const };
+
+	const { Th, thProps } = isSvelteComponent(components.th)
+		? { Th: components.th }
+		: { Th: DefaultComponent, thProps: { type: "th", shorthand: components.th } as const };
+
+	const { Td, tdProps } = isSvelteComponent(components.td)
+		? { Td: components.td }
+		: { Td: DefaultComponent, tdProps: { type: "td", shorthand: components.td } as const };
 </script>
 
 <!-- This formatting is intentional to prevent unwanted whitespace between elements. -->
 {#if isFilled.table(field)}
-	<Table type="table" table={field}>
+	<Table {...tableProps} table={field}>
 		{#if field?.head}
-			<Thead type="thead" head={field.head}>
+			<Thead {...theadProps} head={field.head}>
 				{#each field.head.rows as row (row.key)}
-					<Tr type="tr" {row}>
+					<Tr {...trProps} {row}>
 						{#each row.cells as cell (cell.key)}
-							<Th type="th" {cell}>
+							<Th {...thProps} {cell}>
 								<PrismicRichText field={cell.content} {components} /></Th
 							>{/each}</Tr
 					>{/each}</Thead
-			>{/if}<Tbody type="tbody" body={field.body}>
+			>{/if}<Tbody {...tbodyProps} body={field.body}>
 			{#each field.body.rows as row (row.key)}
-				<Tr type="tr" {row}>
+				<Tr {...trProps} {row}>
 					{#each row.cells as cell (cell.key)}
 						{#if cell.type === "header"}
-							<Th type="th" {cell}>
+							<Th {...thProps} {cell}>
 								<PrismicRichText field={cell.content} {components} /></Th
-							>{:else}<Td type="td" {cell}>
+							>{:else}<Td {...tdProps} {cell}>
 								<PrismicRichText field={cell.content} {components} /></Td
 							>{/if}{/each}</Tr
 				>

--- a/src/PrismicTable/PrismicTable.svelte
+++ b/src/PrismicTable/PrismicTable.svelte
@@ -2,7 +2,11 @@
 	import { type TableField, isFilled } from "@prismicio/client";
 	import { type Component } from "svelte";
 
-	import { isSvelteComponent, type RichTextComponents, type TableComponents } from "../types";
+	import {
+		isSvelteComponent,
+		type RichTextComponents,
+		type TableComponents,
+	} from "../types";
 
 	import PrismicRichText from "../PrismicRichText/PrismicRichText.svelte";
 
@@ -30,27 +34,45 @@
 
 	const { Table, tableProps } = isSvelteComponent(components.table)
 		? { Table: components.table }
-		: { Table: DefaultComponent, tableProps: { type: "table", shorthand: components.table } as const };
+		: {
+				Table: DefaultComponent,
+				tableProps: { type: "table", shorthand: components.table } as const,
+			};
 
 	const { Thead, theadProps } = isSvelteComponent(components.thead)
 		? { Thead: components.thead }
-		: { Thead: DefaultComponent, theadProps: { type: "thead", shorthand: components.thead } as const };
+		: {
+				Thead: DefaultComponent,
+				theadProps: { type: "thead", shorthand: components.thead } as const,
+			};
 
 	const { Tbody, tbodyProps } = isSvelteComponent(components.tbody)
 		? { Tbody: components.tbody }
-		: { Tbody: DefaultComponent, tbodyProps: { type: "tbody", shorthand: components.tbody } as const };
+		: {
+				Tbody: DefaultComponent,
+				tbodyProps: { type: "tbody", shorthand: components.tbody } as const,
+			};
 
 	const { Tr, trProps } = isSvelteComponent(components.tr)
 		? { Tr: components.tr }
-		: { Tr: DefaultComponent, trProps: { type: "tr", shorthand: components.tr } as const };
+		: {
+				Tr: DefaultComponent,
+				trProps: { type: "tr", shorthand: components.tr } as const,
+			};
 
 	const { Th, thProps } = isSvelteComponent(components.th)
 		? { Th: components.th }
-		: { Th: DefaultComponent, thProps: { type: "th", shorthand: components.th } as const };
+		: {
+				Th: DefaultComponent,
+				thProps: { type: "th", shorthand: components.th } as const,
+			};
 
 	const { Td, tdProps } = isSvelteComponent(components.td)
 		? { Td: components.td }
-		: { Td: DefaultComponent, tdProps: { type: "td", shorthand: components.td } as const };
+		: {
+				Td: DefaultComponent,
+				tdProps: { type: "td", shorthand: components.td } as const,
+			};
 </script>
 
 <!-- This formatting is intentional to prevent unwanted whitespace between elements. -->

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,15 +34,15 @@ import type { Component, Snippet } from "svelte";
 /** A shorthand definition for `<PrismicRichText />` and `<PrismicTable />` component types. */
 export type ComponentShorthand = {
 	/** The HTML element type rendered for this node type. */
-	as?: string
+	as?: string;
 
 	/** Other attributes to apply to the element type. */
-	[Attribute: string]: string | boolean | null | undefined
+	[Attribute: string]: string | boolean | null | undefined;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const isSvelteComponent = <T extends Record<string, any>>(
-	component: Component<T> | ComponentShorthand | undefined
+	component: Component<T> | ComponentShorthand | undefined,
 ): component is Component<T> => {
 	return typeof component === "function";
 };
@@ -71,47 +71,62 @@ export type RichTextComponents = {
 
 export type RichTextComponent<TNode extends RTAnyNode = RTAnyNode> = Component<
 	RichTextComponentProps<TNode>
->
+>;
 
 export type RichTextComponentProps<TNode extends RTAnyNode = RTAnyNode> = {
 	node: TNode;
 	children: Snippet;
 };
 
-export type InternalRichTextComponents = Record<RichTextNodeTypes, {
-	is: Component<
-		RichTextComponentProps<RTAnyNode> &
-		{ shorthand?: ComponentShorthand }
-	>,
-	shorthand?: ComponentShorthand;
-} | { is: RichTextComponent, shorthand?: never }>
+export type InternalRichTextComponents = Record<
+	RichTextNodeTypes,
+	| {
+			is: Component<
+				RichTextComponentProps<RTAnyNode> & { shorthand?: ComponentShorthand }
+			>;
+			shorthand?: ComponentShorthand;
+	  }
+	| { is: RichTextComponent; shorthand?: never }
+>;
 
 // Define the type for the components prop
 export type TableComponents = {
-	table?: Component<{
-		table: TableField<"filled">;
-		children: Snippet;
-	}> | ComponentShorthand;
-	thead?: Component<{
-		head: TableFieldHead;
-		children: Snippet;
-	}> | ComponentShorthand;
-	tbody?: Component<{
-		body: TableFieldBody;
-		children: Snippet;
-	}> | ComponentShorthand;
-	tr?: Component<{
-		row: TableFieldHeadRow | TableFieldBodyRow;
-		children: Snippet;
-	}> | ComponentShorthand;
-	th?: Component<{
-		cell: TableFieldHeaderCell;
-		children: Snippet;
-	}> | ComponentShorthand;
-	td?: Component<{
-		cell: TableFieldDataCell;
-		children: Snippet;
-	}> | ComponentShorthand;
+	table?:
+		| Component<{
+				table: TableField<"filled">;
+				children: Snippet;
+		  }>
+		| ComponentShorthand;
+	thead?:
+		| Component<{
+				head: TableFieldHead;
+				children: Snippet;
+		  }>
+		| ComponentShorthand;
+	tbody?:
+		| Component<{
+				body: TableFieldBody;
+				children: Snippet;
+		  }>
+		| ComponentShorthand;
+	tr?:
+		| Component<{
+				row: TableFieldHeadRow | TableFieldBodyRow;
+				children: Snippet;
+		  }>
+		| ComponentShorthand;
+	th?:
+		| Component<{
+				cell: TableFieldHeaderCell;
+				children: Snippet;
+		  }>
+		| ComponentShorthand;
+	td?:
+		| Component<{
+				cell: TableFieldDataCell;
+				children: Snippet;
+		  }>
+		| ComponentShorthand;
 };
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,7 @@ import type {
 	RTPreformattedNode,
 	RTSpanNode,
 	RTStrongNode,
+	RichTextNodeTypes,
 	Slice,
 	TableField,
 	TableFieldBody,
@@ -30,63 +31,87 @@ import type {
 } from "@prismicio/client";
 import type { Component, Snippet } from "svelte";
 
+/** A shorthand definition for `<PrismicRichText />` and `<PrismicTable />` component types. */
+export type ComponentShorthand = {
+	/** The HTML element type rendered for this node type. */
+	as?: string
+
+	/** Other attributes to apply to the element type. */
+	[Attribute: string]: string | boolean | null | undefined
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const isSvelteComponent = <T extends Record<string, any>>(
+	component: Component<T> | ComponentShorthand | undefined
+): component is Component<T> => {
+	return typeof component === "function";
+};
+
 export type RichTextComponents = {
-	heading1?: RichTextComponent<RTHeading1Node>;
-	heading2?: RichTextComponent<RTHeading2Node>;
-	heading3?: RichTextComponent<RTHeading3Node>;
-	heading4?: RichTextComponent<RTHeading4Node>;
-	heading5?: RichTextComponent<RTHeading5Node>;
-	heading6?: RichTextComponent<RTHeading6Node>;
-	paragraph?: RichTextComponent<RTParagraphNode>;
-	preformatted?: RichTextComponent<RTPreformattedNode>;
-	strong?: RichTextComponent<RTStrongNode>;
-	em?: RichTextComponent<RTEmNode>;
-	listItem?: RichTextComponent<RTListItemNode>;
-	oListItem?: RichTextComponent<RTOListItemNode>;
-	list?: RichTextComponent<RTListNode>;
-	oList?: RichTextComponent<RTOListNode>;
-	image?: RichTextComponent<RTImageNode>;
-	embed?: RichTextComponent<RTEmbedNode>;
-	hyperlink?: RichTextComponent<RTLinkNode>;
-	label?: RichTextComponent<RTLabelNode>;
-	span?: RichTextComponent<RTSpanNode>;
+	heading1?: RichTextComponent<RTHeading1Node> | ComponentShorthand;
+	heading2?: RichTextComponent<RTHeading2Node> | ComponentShorthand;
+	heading3?: RichTextComponent<RTHeading3Node> | ComponentShorthand;
+	heading4?: RichTextComponent<RTHeading4Node> | ComponentShorthand;
+	heading5?: RichTextComponent<RTHeading5Node> | ComponentShorthand;
+	heading6?: RichTextComponent<RTHeading6Node> | ComponentShorthand;
+	paragraph?: RichTextComponent<RTParagraphNode> | ComponentShorthand;
+	preformatted?: RichTextComponent<RTPreformattedNode> | ComponentShorthand;
+	strong?: RichTextComponent<RTStrongNode> | ComponentShorthand;
+	em?: RichTextComponent<RTEmNode> | ComponentShorthand;
+	listItem?: RichTextComponent<RTListItemNode> | ComponentShorthand;
+	oListItem?: RichTextComponent<RTOListItemNode> | ComponentShorthand;
+	list?: RichTextComponent<RTListNode> | ComponentShorthand;
+	oList?: RichTextComponent<RTOListNode> | ComponentShorthand;
+	image?: RichTextComponent<RTImageNode> | ComponentShorthand;
+	embed?: RichTextComponent<RTEmbedNode> | ComponentShorthand;
+	hyperlink?: RichTextComponent<RTLinkNode> | ComponentShorthand;
+	label?: RichTextComponent<RTLabelNode> | ComponentShorthand;
+	span?: RichTextComponent<RTSpanNode> | ComponentShorthand;
 };
 
 export type RichTextComponent<TNode extends RTAnyNode = RTAnyNode> = Component<
 	RichTextComponentProps<TNode>
->;
+>
 
 export type RichTextComponentProps<TNode extends RTAnyNode = RTAnyNode> = {
 	node: TNode;
 	children: Snippet;
 };
 
+export type InternalRichTextComponents = Record<RichTextNodeTypes, {
+	is: Component<
+		RichTextComponentProps<RTAnyNode> &
+		{ shorthand?: ComponentShorthand }
+	>,
+	shorthand?: ComponentShorthand;
+} | { is: RichTextComponent, shorthand?: never }>
+
 // Define the type for the components prop
 export type TableComponents = {
 	table?: Component<{
 		table: TableField<"filled">;
 		children: Snippet;
-	}>;
+	}> | ComponentShorthand;
 	thead?: Component<{
 		head: TableFieldHead;
 		children: Snippet;
-	}>;
+	}> | ComponentShorthand;
 	tbody?: Component<{
 		body: TableFieldBody;
 		children: Snippet;
-	}>;
+	}> | ComponentShorthand;
 	tr?: Component<{
 		row: TableFieldHeadRow | TableFieldBodyRow;
 		children: Snippet;
-	}>;
+	}> | ComponentShorthand;
 	th?: Component<{
 		cell: TableFieldHeaderCell;
 		children: Snippet;
-	}>;
+	}> | ComponentShorthand;
 	td?: Component<{
 		cell: TableFieldDataCell;
 		children: Snippet;
-	}>;
+	}> | ComponentShorthand;
 };
 
 /**

--- a/test/PrismicRichText.test.ts
+++ b/test/PrismicRichText.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment happy-dom
+import { expect, it } from "vitest";
+
+import { RichTextField, RichTextNodeType } from "@prismicio/client";
+import { render } from "@testing-library/svelte";
+
+import { PrismicRichText } from "../src";
+
+import RichTextWrapperComponent from "./RichTextWrapperComponent.svelte";
+
+it("renders with default components", () => {
+	const field: RichTextField = [
+		{
+			type: RichTextNodeType.heading1,
+			text: "Heading 1",
+			spans: [],
+		},
+		{
+			type: RichTextNodeType.paragraph,
+			text: "Paragraph text",
+			spans: [],
+		},
+	];
+
+	const { container } = render(PrismicRichText, { field });
+
+	const html = container.innerHTML.replaceAll("<!---->", "");
+	expect(html).toContain("<h1>Heading 1</h1>");
+	expect(html).toContain("<p>Paragraph text</p>");
+});
+
+it("renders with a Svelte component", () => {
+	const field: RichTextField = [
+		{
+			type: RichTextNodeType.heading1,
+			text: "Heading 1",
+			spans: [],
+		},
+	];
+
+	const { container } = render(PrismicRichText, {
+		field,
+		components: {
+			heading1: RichTextWrapperComponent,
+		},
+	});
+
+	expect(container.innerHTML.replaceAll("<!---->", "")).toContain(
+		'<div class="wrapper-component">Heading 1</div>',
+	);
+});
+
+it("renders with shorthand", () => {
+	const field: RichTextField = [
+		{
+			type: RichTextNodeType.heading1,
+			text: "Heading 1",
+			spans: [],
+		},
+		{
+			type: RichTextNodeType.heading2,
+			text: "Heading 2",
+			spans: [],
+		},
+	];
+
+	const { container } = render(PrismicRichText, {
+		field,
+		components: {
+			heading1: {
+				class: "heading-1",
+				"data-testid": "heading-1",
+			},
+			heading2: {
+				as: "h3",
+				class: "heading-2",
+				"data-testid": "heading-2",
+			},
+		},
+	});
+
+	const html = container.innerHTML.replaceAll("<!---->", "");
+	expect(html).toContain(
+		'<h1 class="heading-1" data-testid="heading-1">Heading 1</h1>',
+	);
+	expect(html).toContain(
+		'<h3 class="heading-2" data-testid="heading-2">Heading 2</h3>',
+	);
+});
+

--- a/test/PrismicRichText.test.ts
+++ b/test/PrismicRichText.test.ts
@@ -87,4 +87,3 @@ it("renders with shorthand", () => {
 		'<h3 class="heading-2" data-testid="heading-2">Heading 2</h3>',
 	);
 });
-

--- a/test/RichTextWrapperComponent.svelte
+++ b/test/RichTextWrapperComponent.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+	import type { RichTextComponentProps } from "../src/types";
+
+	const { children }: RichTextComponentProps = $props();
+</script>
+
+<div class="wrapper-component">{@render children()}</div>
+

--- a/test/RichTextWrapperComponent.svelte
+++ b/test/RichTextWrapperComponent.svelte
@@ -5,4 +5,3 @@
 </script>
 
 <div class="wrapper-component">{@render children()}</div>
-

--- a/test/table/PrismicTable.test.ts
+++ b/test/table/PrismicTable.test.ts
@@ -12,6 +12,7 @@ import CustomTHead from "./CustomTHead.svelte";
 import CustomTR from "./CustomTR.svelte";
 import CustomTable from "./CustomTable.svelte";
 import PrismicTableFallback from "./TableFallback.svelte";
+import TableWrapperComponent from "./TableWrapperComponent.svelte";
 
 import { PrismicTable } from "../../src";
 
@@ -95,6 +96,90 @@ const filledTableField: TableField = {
 	},
 };
 
+const simpleTableField: TableField = {
+	head: {
+		rows: [
+			{
+				key: "0",
+				cells: [
+					{
+						key: "0",
+						type: "header",
+						content: [{ type: "paragraph", text: "Header", spans: [] }],
+					},
+				],
+			},
+		],
+	},
+	body: {
+		rows: [
+			{
+				key: "0",
+				cells: [
+					{
+						key: "0",
+						type: "data",
+						content: [{ type: "paragraph", text: "Data", spans: [] }],
+					},
+				],
+			},
+		],
+	},
+};
+
+it("renders with default components", () => {
+	const { container } = render(PrismicTable, { field: simpleTableField });
+
+	const html = container.innerHTML.replaceAll("<!---->", "");
+	expect(html).toContain("<table>");
+	expect(html).toContain("<thead>");
+	expect(html).toContain("<tbody>");
+	expect(html).toContain("<th>");
+	expect(html).toContain("<td>");
+	expect(html).toContain("Header");
+	expect(html).toContain("Data");
+});
+
+it("renders with a Svelte component", () => {
+	const { container } = render(PrismicTable, {
+		field: simpleTableField,
+		components: {
+			table: TableWrapperComponent,
+		},
+	});
+
+	const html = container.innerHTML.replaceAll("<!---->", "");
+	expect(html).toContain('<div class="wrapper-table">');
+	expect(html).toContain("Header");
+	expect(html).toContain("Data");
+});
+
+it("renders with shorthand", () => {
+	const { container } = render(PrismicTable, {
+		field: simpleTableField,
+		components: {
+			table: {
+				class: "custom-table",
+				"data-testid": "table",
+			},
+			th: {
+				class: "custom-th",
+				"data-testid": "th",
+			},
+			td: {
+				as: "th",
+				class: "custom-td",
+				"data-testid": "td",
+			},
+		},
+	});
+
+	const html = container.innerHTML.replaceAll("<!---->", "");
+	expect(html).toContain('<table class="custom-table" data-testid="table">');
+	expect(html).toContain('<th class="custom-th" data-testid="th">');
+	expect(html).toContain('<th class="custom-td" data-testid="td">');
+});
+
 it("renders filled table elements", () => {
 	const { container } = render(PrismicTable, { field: filledTableField });
 
@@ -104,6 +189,7 @@ it("renders filled table elements", () => {
 });
 
 it("renders null when passed an empty field", () => {
+	// @ts-expect-error - undefined is not a valid TableField
 	const { container } = render(PrismicTable, { field: undefined });
 
 	expect(container.innerHTML.replaceAll("<!---->", "")).toBe("");
@@ -111,6 +197,7 @@ it("renders null when passed an empty field", () => {
 
 it("renders fallback when passed an empty field", () => {
 	const { container } = render(PrismicTable, {
+		// @ts-expect-error - undefined is not a valid TableField
 		field: undefined,
 		fallback: PrismicTableFallback,
 	});

--- a/test/table/PrismicTable.test.ts
+++ b/test/table/PrismicTable.test.ts
@@ -189,7 +189,6 @@ it("renders filled table elements", () => {
 });
 
 it("renders null when passed an empty field", () => {
-	// @ts-expect-error - undefined is not a valid TableField
 	const { container } = render(PrismicTable, { field: undefined });
 
 	expect(container.innerHTML.replaceAll("<!---->", "")).toBe("");
@@ -197,7 +196,6 @@ it("renders null when passed an empty field", () => {
 
 it("renders fallback when passed an empty field", () => {
 	const { container } = render(PrismicTable, {
-		// @ts-expect-error - undefined is not a valid TableField
 		field: undefined,
 		fallback: PrismicTableFallback,
 	});

--- a/test/table/TableWrapperComponent.svelte
+++ b/test/table/TableWrapperComponent.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
-	import type { TableField } from "@prismicio/client";
 	import type { Snippet } from "svelte";
 
-	const { children }: { table: TableField<"filled">; children: Snippet } =
-		$props();
+	const { children }: { children: Snippet } = $props();
 </script>
 
 <div class="wrapper-table">{@render children()}</div>

--- a/test/table/TableWrapperComponent.svelte
+++ b/test/table/TableWrapperComponent.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+	import type { TableField } from "@prismicio/client";
+	import type { Snippet } from "svelte";
+
+	const { table, children }: { table: TableField<"filled">; children: Snippet } = $props();
+</script>
+
+<div class="wrapper-table">{@render children()}</div>
+

--- a/test/table/TableWrapperComponent.svelte
+++ b/test/table/TableWrapperComponent.svelte
@@ -2,8 +2,8 @@
 	import type { TableField } from "@prismicio/client";
 	import type { Snippet } from "svelte";
 
-	const { table, children }: { table: TableField<"filled">; children: Snippet } = $props();
+	const { children }: { table: TableField<"filled">; children: Snippet } =
+		$props();
 </script>
 
 <div class="wrapper-table">{@render children()}</div>
-


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

Resolves: N/A

### Description

This PR updates `<PrismicRichText>` and `<PrismicTable>` to support shorthand definition of their `components` prop. In common scenarios, defining dedicated components for each node type cannot be done inline and requires some boilerplate in Svelte, which is inconvenient.

This works similarly to `asHTML()` shorthand serializer: https://github.com/prismicio/prismic-client/blob/248534df3d8d9330191784581def2952f053b758/src/helpers/asHTML.ts#L122-L135, with the added `as` special property.

**Before:**

```svelte
<script lang="ts">
	import Heading from "~/components/Heading.svelte";
	import Paragraph from "~/components/Paragraph.svelte";
</script>

<PrismicRichText
	field={slice.primary.my_rich_text_field}
	components={{
		heading1: Heading,
		paragraph: Paragraph,
	}}
/>

<!-- components/Heading.svelte -->
<h1 class="text-xl font-bold"><slot /></h1>

<!-- components/Paragraph.svelte -->
<p class="my-8"><slot /></p>
```

**Can now be written as:**

```svelte
<PrismicRichText
	field={slice.primary.my_rich_text_field}
	components={{
		heading1: { class: "text-xl font-bold" },
		paragraph: { class: "my-8" },
	}}
/>
```

**Rendered element can be changed:**

```svelte
<!-- "heading1" nodes will render with an "h2" element -->
<PrismicRichText
	field={slice.primary.my_rich_text_field}
	components={{
		heading1: { as: "h2", class: "text-xl font-bold" },
		paragraph: { class: "my-8" },
	}}
/>
```

**Mixing shorthands and components is supported:**

```svelte
<script lang="ts">
	import Heading from "~/components/Heading.svelte";
</script>

<PrismicRichText
	field={slice.primary.my_rich_text_field}
	components={{
		heading1: Heading,
		paragraph: { class: "my-8" },
	}}
/>

<!-- components/Heading.svelte -->
<h1 class="text-xl font-bold"><slot /></h1>
```

**Works in a similar way with `<PrismicTable>`:**

```svelte
<PrismicTable
	field={slice.primary.my_table_field}
	components={{
		table: { class: "my-table" },
		tbody: { class: "my-tbody" },
		paragraph: { as: "span", class: "text-sm" },
	}}
/>
```

*[This would have greatly simplified such code for example](https://github.com/prismicio-community/nuxt-starter-prismic-farbe/tree/master/app/slices/Product)*

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

---

[**From the `asHTML()`'s shorthand PR:**](https://github.com/prismicio/prismic-client/pull/321#pullrequestreview-1611532976) 

> Do you have any ideas on how we could share shorthand logic between rich text renderers? Maybe a set of helpers that could be exported from `@prismicio/client/richtext`?

Now that we have a concrete "second implementation" here, I'm not sure really how we could have such helpers.

I had to use some ["internal maps"](https://github.com/prismicio/prismic-svelte/blob/main/src/PrismicRichText/PrismicRichText.svelte#L37-L57) in this PR to be able to forward to sub-components the components to use and their eventual additional props, which the HTML version of it had nothing to do with. On the contrary, the HTML version had to [support more logic to render attributes](https://github.com/prismicio/prismic-client/blob/248534df3d8d9330191784581def2952f053b758/src/lib/serializerHelpers.ts#L14-L58), which is not needed in JavaScript framework-land.

The logic in [`<PrismicRichText>`](https://github.com/prismicio/prismic-svelte/blob/main/src/PrismicRichText/PrismicRichText.svelte#L27-L35) is comparable to the [one here](https://github.com/prismicio/prismic-client/blob/248534df3d8d9330191784581def2952f053b758/src/helpers/asHTML.ts#L153-L255), but since we cannot really compose/prepare Svelte components like JavaScript functions, I don't really know 🤔

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [x] If my changes require tests, I added them.
- [x] If my changes affect backward compatibility, it has been discussed.
- [x] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
