### PR TITLE
feat(runes): rewrite SliceSimulator and test component to runes

### DIFF
--- a/src/SliceSimulator.svelte
+++ b/src/SliceSimulator.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import type { SliceZone } from "@prismicio/client";
 	import {
 		SimulatorManager,
 		StateEventType,
@@ -10,14 +11,28 @@
 		simulatorClass,
 		simulatorRootClass,
 	} from "@prismicio/simulator/kit";
+	import { onMount } from "svelte";
+	import type { Snippet } from "svelte";
+	import type { ClassValue } from "svelte/elements";
 
 	const defaultProps = getDefaultProps();
 
-	export let zIndex = defaultProps.zIndex;
-	export let background = defaultProps.background;
+	type Props = {
+		zIndex?: number;
+		background?: string;
+		class?: ClassValue;
+		children: Snippet<[{ slices: SliceZone }]>;
+	};
 
-	let slices = getDefaultSlices();
-	let message = getDefaultMessage();
+	const {
+		zIndex = defaultProps.zIndex,
+		background = defaultProps.background,
+		class: classes,
+		children,
+	}: Props = $props();
+
+	let slices = $state(getDefaultSlices());
+	let message = $state(getDefaultMessage());
 
 	if (typeof window !== "undefined") {
 		const simulatorManager = new SimulatorManager();
@@ -42,7 +57,7 @@
 </script>
 
 <div
-	class="{simulatorClass} {$$props.class}"
+	class={[simulatorClass, classes]}
 	style="z-index: {zIndex}; position: fixed; top: 0; left: 0; width: 100%; height: 100vh; overflow: auto; background: {background}"
 >
 	{#if message}
@@ -51,15 +66,15 @@
 			{@html message}
 		</article>
 	{:else if slices.length}
-		<!-- svelte-ignore a11y-no-static-element-interactions -->
+		<!-- svelte-ignore a11y_no_static_element_interactions, event_directive_deprecated -->
 		<div
 			id="root"
 			class={simulatorRootClass}
-			on:click={onClickHandler}
-			on:submit={disableEventHandler}
-			on:keypress={disableEventHandler}
+			onclick={onClickHandler}
+			onsubmit={disableEventHandler}
+			onkeypress={disableEventHandler}
 		>
-			<slot {slices} />
+			{@render children({ slices })}
 		</div>
 	{/if}
 </div>

--- a/src/SliceSimulator.svelte
+++ b/src/SliceSimulator.svelte
@@ -11,7 +11,6 @@
 		simulatorClass,
 		simulatorRootClass,
 	} from "@prismicio/simulator/kit";
-	import { onMount } from "svelte";
 	import type { Snippet } from "svelte";
 	import type { ClassValue } from "svelte/elements";
 

--- a/test/PrismicLinkTestWrapper.svelte
+++ b/test/PrismicLinkTestWrapper.svelte
@@ -8,8 +8,12 @@ passing slot content to the PrismicLink component is not easy in tests.
 
 	import { PrismicLink } from "../src";
 
-	export let field: FilledLinkToWebField;
-	export let children: string | undefined = undefined;
+	type Props = {
+		field: FilledLinkToWebField;
+		children?: string;
+	};
+
+	const { field, children }: Props = $props();
 </script>
 
 {#if children}


### PR DESCRIPTION
## Changes
Rewrites `SliceSimulator` & `PrismicLinkTestWrapper` to Svelte 5 runes.

## Fixes
Fixes https://github.com/prismicio/prismic-svelte/pull/40 which introduced Svelte 4 syntax which shoudnl't occur in the new codebase as https://github.com/prismicio/prismic-svelte/pull/32/ has been already merged.

## ⚠️ Breaking change
Since `<slot />` has been deprecated and it is recommended to use snippets instead.

So this will **no longer work**:
```svelte
<SliceSimulator let:slices>
	...
</SliceSimulator>
```
And you should do:
```svelte
<SliceSimulator>
	{#snippet children({ slices })}
		...
	{/snippet}
</SliceSimulator>
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/prismicio/codesmith/prismic-svelte/pr/44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a **breaking API change** in `SliceSimulator` (slot → required snippet) that can break consumers at compile-time; runtime logic changes are otherwise localized to UI/event wiring.
> 
> **Overview**
> Updates `SliceSimulator` and `PrismicLinkTestWrapper` to Svelte 5 runes by switching to `$props()`/`$state()` and modern event bindings (`onclick`/`onsubmit`/`onkeypress`) and class handling.
> 
> `SliceSimulator` now renders content via a required `children` snippet (`{@render ...}`) instead of `<slot {slices} />`, changing the public usage from `let:slices` slot props to snippet-based rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e71dd1514f78978b0a7799bed26d327dab58fac0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->